### PR TITLE
FIX: Validate time-string attribute

### DIFF
--- a/drmaa_patches.py
+++ b/drmaa_patches.py
@@ -6,6 +6,13 @@ from drmaa import JobTemplate, Session
 from drmaa.helpers import Attribute, IntConverter
 
 
+#TODO: Make sure this is actually correct?
+# Works for SLURM
+CORRECT_TO_STRING = [
+        "hardWallclockTimeLimit"
+]
+
+
 class PatchedIntConverter():
     '''
     Helper class to correctly encode Integer values
@@ -33,7 +40,9 @@ class PatchedJobTemplate(JobTemplate):
         super(PatchedJobTemplate, self).__init__()
         for attr, value in vars(JobTemplate).items():
             if isinstance(value, Attribute):
-                if value.converter is IntConverter:
+                if attr in CORRECT_TO_STRING:
+                    setattr(value, "converter", None)
+                elif value.converter is IntConverter:
                     setattr(value, "converter", PatchedIntConverter)
 
 

--- a/tests/test_config_adapters.py
+++ b/tests/test_config_adapters.py
@@ -65,3 +65,29 @@ def test_slurm_config_native_spec_transforms_correctly(job_template):
     jt = slurm_config.get_drmaa_config(job_template)
     for spec in ['account=TEST', 'cpus-per-task=5']:
         assert spec in jt.nativeSpecification
+
+
+def test_invalid_timestr_fails():
+    job_name = "TEST"
+    time = "FAILURE"
+    account = "TEST"
+    cpus_per_task = 10
+
+    with pytest.raises(ValueError):
+        SlurmConfig(job_name=job_name,
+                    time=time,
+                    account=account,
+                    cpus_per_task=cpus_per_task)
+
+
+def test_timestr_not_string_fails():
+    job_name = "TEST"
+    time = 10
+    account = "TEST"
+    cpus_per_task = 10
+
+    with pytest.raises(TypeError):
+        SlurmConfig(job_name=job_name,
+                    time=time,
+                    account=account,
+                    cpus_per_task=cpus_per_task)

--- a/tests/test_config_adapters.py
+++ b/tests/test_config_adapters.py
@@ -25,13 +25,13 @@ def test_slurm_config_transforms_to_drmaa(job_template):
 
     error = "TEST_VALUE"
     output = "TEST_VALUE"
-    time = "10:00:00"  # must test as seconds
+    time = "10:00:00"
     job_name = "FAKE_JOB"
 
     expected_drmaa_attrs = {
         "errorPath": error,
         "outputPath": output,
-        "hardWallclockTimeLimit": 36000,
+        "hardWallclockTimeLimit": "10:00:00",
         "jobName": job_name
     }
 
@@ -54,7 +54,7 @@ def test_slurm_config_native_spec_transforms_correctly(job_template):
     '''
 
     job_name = "TEST"
-    time = "1:00"
+    time = "01:00"
     account = "TEST"
     cpus_per_task = 5
     slurm_config = SlurmConfig(job_name=job_name,


### PR DESCRIPTION
This is a small fix implemented that ensures that the DRMAA API can receive a time-string formatted as (X.XXX:XX:XX or XX:XX) rather than enforcing an integer.

Currently this has been tested on the slurm-drmaa API, however it is possible other APIs require an integer value. This requires testing and possibly writing DRM-specific patches