### PR TITLE
FIX: Provide default DRMAA config for legacy DAGs

### DIFF
--- a/drmaa_executor_plugin/config_adapters.py
+++ b/drmaa_executor_plugin/config_adapters.py
@@ -3,7 +3,7 @@ Configuration adapters for mapping native specifications from DRM to DRMAA API
 """
 
 from __future__ import annotations
-from typing import (List, ClassVar, Union, Optional, TYPE_CHECKING, Bool)
+from typing import (List, ClassVar, Union, Optional, TYPE_CHECKING)
 
 from dataclasses import dataclass, asdict, fields, InitVar
 from abc import ABC, abstractmethod
@@ -95,7 +95,7 @@ class DRMAACompatible(ABC):
 class DRMAAConfig(DRMAACompatible):
 
     remoteCommand: str
-    blockEmail: Optional[Bool] = False
+    blockEmail: Optional[bool] = False
 
     args: Optional[List[str]] = None
 

--- a/drmaa_executor_plugin/config_adapters.py
+++ b/drmaa_executor_plugin/config_adapters.py
@@ -94,6 +94,8 @@ class DRMAACompatible(ABC):
 @dataclass
 class DRMAAConfig(DRMAACompatible):
 
+    _mapped_fields: ClassVar[List[str]] = []
+
     blockEmail: Optional[bool] = False
 
     args: Optional[List[str]] = None
@@ -126,9 +128,9 @@ class SlurmConfig(DRMAACompatible):
         details
     '''
 
-    _mapped_fields: ClassVar[List[str]] = {
+    _mapped_fields: ClassVar[List[str]] = [
         "error", "output", "job_name", "time"
-    }
+    ]
 
     job_name: InitVar[str]
     time: InitVar[str]

--- a/drmaa_executor_plugin/config_adapters.py
+++ b/drmaa_executor_plugin/config_adapters.py
@@ -3,7 +3,7 @@ Configuration adapters for mapping native specifications from DRM to DRMAA API
 """
 
 from __future__ import annotations
-from typing import (List, ClassVar, Union, Optional, TYPE_CHECKING)
+from typing import (List, ClassVar, Union, Optional, TYPE_CHECKING, Bool)
 
 from dataclasses import dataclass, asdict, fields, InitVar
 from abc import ABC, abstractmethod
@@ -93,6 +93,26 @@ class DRMAACompatible(ABC):
 
 @dataclass
 class DRMAAConfig(DRMAACompatible):
+
+    remoteCommand: str
+    blockEmail: Optional[Bool] = False
+
+    args: Optional[List[str]] = None
+
+    jobName: Optional[str] = None
+    jobCategory: Optional[str] = None
+    inputPath: Optional[str] = None
+    errorPath: Optional[str] = None
+    outputPath: Optional[str] = None
+
+    hardWallclockTimeLimit: Optional[str] = None
+    hardRunDurationLimit: Optional[int] = None
+    deadlineTime: Optional[str] = None
+
+    email: Optional[str] = None
+    workingDirectory: Optional[str] = None
+    transferFiles: Optional[str] = None
+
     def drm2drmaa(self):
         return
 

--- a/drmaa_executor_plugin/config_adapters.py
+++ b/drmaa_executor_plugin/config_adapters.py
@@ -94,7 +94,6 @@ class DRMAACompatible(ABC):
 @dataclass
 class DRMAAConfig(DRMAACompatible):
 
-    remoteCommand: str
     blockEmail: Optional[bool] = False
 
     args: Optional[List[str]] = None

--- a/drmaa_executor_plugin/executors/drmaa_executor.py
+++ b/drmaa_executor_plugin/executors/drmaa_executor.py
@@ -105,6 +105,8 @@ class DRMAAV1Executor(BaseExecutor, LoggingMixin):
                         "jobName": "airflow-scheduled",
                         "hardWallclockTimeLimit": "1:00",
                     }))
+            self.log.info("Default settings:")
+            self.log.info(f"{self.default_executor_config}")
 
         self.log.info(
             "Getting job tracking Airflow Variable: `scheduler_job_ids`")
@@ -159,6 +161,9 @@ class DRMAAV1Executor(BaseExecutor, LoggingMixin):
         executor_config is empty dict by default, it'll be filled with
         default values if not specified
         '''
+        if not executor_config and self.default_executor_config is not None:
+            self.log.info("No executor config provided, using defaults")
+            executor_config = self.default_executor_config
 
         self.log.info(f"Submitting job {key} with command {command} with"
                       f" configuration options:\n{executor_config})")


### PR DESCRIPTION
This will enable running legacy DAGs using DRMAAExecutor, note that they will run with standard settings. Will need to add documentation for how to configure this..